### PR TITLE
Publish build artefacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,3 +47,8 @@ jobs:
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: ${{runner.os}}-fcc
+        path: ${{github.workspace}}/build/fcc


### PR DESCRIPTION
Artefacts are published on the action as such:
https://github.com/Kwarf/dz/actions/runs/2197426693